### PR TITLE
詳細画面の表示&登録処理の改修

### DIFF
--- a/data/db.json
+++ b/data/db.json
@@ -31,6 +31,22 @@
       "imageUrl": "aaa",
       "deleted": true,
       "id": 5
+    },
+    {
+      "name": "練習素材",
+      "description": "お試しです",
+      "price": "1111",
+      "imageUrl": "urlurlurl",
+      "deleted": false,
+      "id": 6
+    },
+    {
+      "name": "商品7",
+      "description": "description",
+      "price": "2222",
+      "imageUrl": "url",
+      "deleted": false,
+      "id": 7
     }
   ]
 }

--- a/src/components/GetItemId.tsx
+++ b/src/components/GetItemId.tsx
@@ -18,5 +18,5 @@ export async function GetItemId() {
     },
   }))
 
-  return { paths};
+  return {paths};
 }

--- a/src/components/GetItemList.tsx
+++ b/src/components/GetItemList.tsx
@@ -36,7 +36,7 @@ export default function GetItemList() {
             <td>{item.name}</td>
             <td>{item.description}</td>
             <td>
-              <Link href="/">詳細</Link>
+              <Link href={`/items/${item.id}`}>詳細</Link>
             </td>
             <td>
               <button type="submit" onClick={() => del(item.id)}>削除</button>

--- a/src/pages/items/[id].tsx
+++ b/src/pages/items/[id].tsx
@@ -1,7 +1,6 @@
 import { GetItemId } from 'components/GetItemId';
 import { GetItemDetail } from 'components/GetItemDetail';
-import UseSWR from 'swr';
-const fetcher = (url: string) => fetch(url).then((res) => res.json());
+import Link from "next/link";
 
 // jsonの型
 type Item = {
@@ -14,8 +13,8 @@ type Item = {
 };
 
 export async function getStaticPaths() {
-  //   const paths = GetItemId();
-  // 商品ID一覧を取得する
+  //const paths = GetItemId();
+  //商品ID一覧を取得する
   const res = await fetch('http://localhost:8000/items/');
   const posts = await res.json();
   const paths = posts.map((item: Item) => ({
@@ -40,29 +39,26 @@ export async function getStaticProps({ params}: {params: { id: string };}) {
 
 export default function detail({ data }: { data: Item }) {
   return (
-    <table>
-      <tr>
-        <th>ID</th>
-        <th>商品名</th>
-        <th>商品の説明</th>
-        <th>価格</th>
-        <th>イメージ画像</th>
-        <th>削除フラグ</th>
-      </tr>
-      <tr>
-        {/* <td>{data.id}</td>
-        <td>{data.name}</td>
-        <td>{data.description}</td>
-        <td>{data.price}</td>
-        <td>{data.imageUrl}</td>
-        <td>{data.imageUrl}</td> */}
-        <td>ID</td>
-        <td>Name</td>
-        <td>BB</td>
-        <td>AAA</td>
-        <td>URL</td>
-        <td>true</td>
-      </tr>
-    </table>
+    <>
+      <table>
+        <tr>
+          <th>ID</th>
+          <th>商品名</th>
+          <th>商品の説明</th>
+          <th>価格</th>
+          <th>イメージ画像</th>
+          <th>削除フラグ</th>
+        </tr>
+        <tr>
+          <td>{data.id}</td>
+          <td>{data.name}</td>
+          <td>{data.description}</td>
+          <td>{data.price}</td>
+          <td>{data.imageUrl}</td>
+          <td>{data.deleted ? 'true':'false'}</td>
+        </tr>
+      </table>
+    <Link href="/">一覧へ</Link>
+    </>
   );
 }

--- a/src/pages/items/create.tsx
+++ b/src/pages/items/create.tsx
@@ -1,12 +1,12 @@
 import { useForm, SubmitHandler } from 'react-hook-form';
 import Link from 'next/link';
-type FormValues = {name: string, description:string, price:number,imageUrl: string};
+type FormValues = {name: string, description:string, price:number,imageUrl: string, deleted:boolean};
 
 export default function Regist() {
 
   const { register, handleSubmit, formState: { errors }} = useForm<FormValues>();
-  // const onSubmit:SubmitHandler<FormValues> = (data) => console.log(data);
   const onSubmit:SubmitHandler<FormValues> = (data) => {
+  data.deleted = false;
   fetch('http://localhost:8000/items',{method: 'POST', headers:{'Content-Type': 'application/json'}, body: JSON.stringify(data),}).then((response) => {console.log(response)});
   };
 


### PR DESCRIPTION
### タスク
1. https://github.com/Riku-Fudo/tenant-app/issues/17#issue-1449049471
2. https://github.com/Riku-Fudo/tenant-app/issues/15#issue-1447734781

### 実装
- 一覧ページに詳細画面のリンク付与
- 登録処理にdeletedを追加