### PR TITLE
更新処理,イベント後処理

### DIFF
--- a/data/db.json
+++ b/data/db.json
@@ -1,7 +1,7 @@
 {
   "items": [
     {
-      "name": "ダミー商品",
+      "name": "商品2",
       "description": "商品の説明",
       "price": 1000,
       "imageUrl": "url",
@@ -9,7 +9,7 @@
       "id": 2
     },
     {
-      "name": "商品名",
+      "name": "商品名3",
       "price": 2000,
       "description": "商品の説明",
       "imageUrl": "url",
@@ -29,24 +29,48 @@
       "description": "description",
       "price": "4000",
       "imageUrl": "aaa",
-      "deleted": true,
+      "deleted": false,
       "id": 5
     },
     {
-      "name": "練習素材",
+      "name": "更新素材",
       "description": "お試しです",
-      "price": "1111",
+      "price": 1111,
       "imageUrl": "urlurlurl",
       "deleted": false,
       "id": 6
     },
     {
-      "name": "商品7",
+      "name": "更新した商品です",
       "description": "description",
-      "price": "2222",
+      "price": 1111,
       "imageUrl": "url",
       "deleted": false,
       "id": 7
+    },
+    {
+      "name": "商品8",
+      "description": "description",
+      "price": 110,
+      "imageUrl": "/images/item.jpg",
+      "deleted": false,
+      "id": 8
+    },
+    {
+      "name": "ドーナツ",
+      "description": "ドーナツ",
+      "price": 500,
+      "imageUrl": "/images/donatu.jpg",
+      "deleted": false,
+      "id": 9
+    },
+    {
+      "deleted": false,
+      "name": "練習素材",
+      "description": "お試しです",
+      "price": "6000",
+      "imageUrl": "url",
+      "id": 10
     }
   ]
 }

--- a/posts/post.tsx
+++ b/posts/post.tsx
@@ -1,0 +1,23 @@
+// jsonの型
+type Item = {
+    id?: number;
+    name?: string;
+    description?: string;
+    price?: number;
+    imageUrl?: string;
+    deleted?: boolean;
+  };
+
+export async function FetchData(data: Item, method:string) {
+let url = '';
+if(data.id){    
+    url = `http://localhost:8000/items/${data.id}`;
+}else{
+    url = 'http://localhost:8000/items';
+}
+await fetch(url, {
+    method: method,
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data),
+  });
+}

--- a/src/components/GetItemList.tsx
+++ b/src/components/GetItemList.tsx
@@ -1,18 +1,21 @@
 import UseSWR from 'swr';
 import Link from "next/link";
+import { FetchData } from '../../posts/post';
+import { useRouter } from 'next/router'
 
 const fetcher = (url: string) => fetch(url).then((res) => res.json());
 
-const del = (id:number) => {
-  const data = {deleted: true};
-  fetch(`http://localhost:8000/items/${id}`,{method: 'PATCH', headers:{'Content-Type': 'application/json'}, body: JSON.stringify(data),}).then((response) => {console.log(response)});
-};
-
 // 商品一覧の取得と描画
 export default function GetItemList() {
+  const router = useRouter();
+  const del = (id:number) => {
+    const data = {id: id, deleted: true};
+    FetchData(data,'PATCH').then(() => router.reload());
+  };
+
   // 商品一覧を取得する
   const { data, error } = UseSWR(
-    'api/items',
+    'api/items?deleted=false',
     fetcher
   );
   // エラーなら一覧取得失敗を画面表示
@@ -29,7 +32,7 @@ export default function GetItemList() {
         <th>詳細画面へ</th>
         <th>削除</th>
       </tr>
-      {data.filter((item:{deleted: boolean}) => !item.deleted).map(
+      {data.map(
         (item: { id: number; name: string; description: string}) => (
           <tr key={item.id}>
             <td>{item.id}</td>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -4,6 +4,16 @@ import styles from '../styles/Home.module.css';
 import GetItemList from 'components/GetItemList';
 import Link from 'next/link';
 
+// jsonの型
+type Item = {
+  id: number;
+  name: string;
+  description: string;
+  price: number;
+  imageUrl: string;
+  deleted: boolean;
+};
+
 export default function Home() {
   return (
     <div className={styles.container}>

--- a/src/pages/items/[id].tsx
+++ b/src/pages/items/[id].tsx
@@ -1,6 +1,17 @@
 import { GetItemId } from 'components/GetItemId';
 import { GetItemDetail } from 'components/GetItemDetail';
-import Link from "next/link";
+import { useForm, SubmitHandler } from 'react-hook-form';
+import Link from 'next/link';
+import { FetchData } from '../../../posts/post';
+import { useRouter } from 'next/router'
+
+type FormValues = {
+  id: number,
+  name: string;
+  description: string;
+  price: number;
+  imageUrl: string;
+};
 
 // jsonの型
 type Item = {
@@ -28,37 +39,50 @@ export async function getStaticPaths() {
   };
 }
 
-export async function getStaticProps({ params}: {params: { id: string };}) {
-    const data = await GetItemDetail(params.id);
-    return {
-        props:{
-            data
-        }
-    }
+export async function getStaticProps({
+  params,
+}: {
+  params: { id: string };
+}) {
+  const data = await GetItemDetail(params.id);
+  return {
+    props: {
+      data,
+    },
+  };
 }
 
-export default function detail({ data }: { data: Item }) {
+export default function Detail({ data }: { data: Item }) {
+  const router = useRouter();
+  const { register, handleSubmit} = useForm<FormValues>({defaultValues: {id: data.id, name: data.name, description:data.description, price:data.price, imageUrl: data.imageUrl }});
+  const onSubmit:SubmitHandler<FormValues> = (data) => {
+    data.price = Number(data.price);
+    FetchData(data,'PATCH').then(() => router.push(`/`));
+  } 
   return (
     <>
-      <table>
-        <tr>
-          <th>ID</th>
-          <th>商品名</th>
-          <th>商品の説明</th>
-          <th>価格</th>
-          <th>イメージ画像</th>
-          <th>削除フラグ</th>
-        </tr>
-        <tr>
-          <td>{data.id}</td>
-          <td>{data.name}</td>
-          <td>{data.description}</td>
-          <td>{data.price}</td>
-          <td>{data.imageUrl}</td>
-          <td>{data.deleted ? 'true':'false'}</td>
-        </tr>
-      </table>
-    <Link href="/">一覧へ</Link>
+      <form onSubmit={handleSubmit(onSubmit)}>
+        <table>
+          <tr>
+            <th>ID</th>
+            <th>商品名</th>
+            <th>商品の説明</th>
+            <th>価格</th>
+            <th>イメージ画像</th>
+            <th>削除フラグ</th>
+          </tr>
+          <tr>
+            <td><input id="id" type="hidden" {...register('id')} />{data.id}</td>
+            <td><input id="name" {...register('name')} /></td>
+            <td><input id="description" {...register('description')} /></td>
+            <td><input id="price" {...register('price')} /></td>
+            <td><input id="imageUrl" {...register('imageUrl')} /></td>
+            <td>{data.deleted ? 'true' : 'false'}</td>
+          </tr>
+        </table>
+        <button type="submit">更新</button>
+      </form>
+      <Link href="/">一覧へ</Link>
     </>
   );
 }

--- a/src/pages/items/create.tsx
+++ b/src/pages/items/create.tsx
@@ -1,13 +1,26 @@
 import { useForm, SubmitHandler } from 'react-hook-form';
 import Link from 'next/link';
-type FormValues = {name: string, description:string, price:number,imageUrl: string, deleted:boolean};
+import { FetchData } from '../../../posts/post';
+
+type FormValues = {
+  name: string;
+  description: string;
+  price: number;
+  imageUrl: string;
+  deleted: boolean;
+};
 
 export default function Regist() {
-
-  const { register, handleSubmit, formState: { errors }} = useForm<FormValues>();
-  const onSubmit:SubmitHandler<FormValues> = (data) => {
-  data.deleted = false;
-  fetch('http://localhost:8000/items',{method: 'POST', headers:{'Content-Type': 'application/json'}, body: JSON.stringify(data),}).then((response) => {console.log(response)});
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+    reset,
+  } = useForm<FormValues>({defaultValues: {deleted:false}});
+  const onSubmit: SubmitHandler<FormValues> = (data) => {
+    FetchData(data,'POST').then(() => {
+      reset();
+    });
   };
 
   return (
@@ -17,8 +30,13 @@ export default function Regist() {
         <ul>
           <li>
             <label id="name">商品名：</label>
-            <input id="name" {...register('name', {required: true})} />
-            {errors.name && <div className="errorMessage">入力が必須の項目です</div>}
+            <input
+              id="name"
+              {...register('name', { required: true })}
+            />
+            {errors.name && (
+              <div className="errorMessage">入力が必須の項目です</div>
+            )}
           </li>
           <li>
             <label id="description">説明：</label>


### PR DESCRIPTION
### タスク
1. https://github.com/Riku-Fudo/tenant-app/issues/21#issue-1449183243
2. https://github.com/Riku-Fudo/tenant-app/issues/20#issue-1449181458

### 実装
- 一覧取得時deleted:trueのみで取得
- イベント時のfetchを共通化
- イベント後の画面遷移を追加
- 更新処理を追加
